### PR TITLE
steam-api: Lower timeout to match the mobile client

### DIFF
--- a/steam/steam-api.h
+++ b/steam/steam-api.h
@@ -78,9 +78,9 @@
  * STEAM_API_TIMEOUT:
  *
  * The timeout (in seconds) of a poll request. This value should not
- * exceed `30`.
+ * exceed `25`. Higher values result in frequent HTTP 500 responses.
  */
-#define STEAM_API_TIMEOUT  30
+#define STEAM_API_TIMEOUT  25
 
 /**
  * STEAM_API_IDLEOUT_AWAY:


### PR DESCRIPTION
This fixes random HTTP 500 responses that eventually result in
disconnects with: "Error: HTTP: Response truncated".